### PR TITLE
Extended RTA for FRAM-4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <timestamp>${maven.build.timestamp}</timestamp>
         <red5pro-common.version>9.1.0</red5pro-common.version>
         <red5.version>1.2.8</red5.version>
+         <red5pro-mega.version>9.0.0</red5pro-mega.version>
         <mina.version>[2.0.21,)</mina.version>
         <spring.version>[5.3.5,)</spring.version>
         <httpcomponents.version>[4.5.13,)</httpcomponents.version>
@@ -265,6 +266,11 @@
         </plugins>
     </build>
     <dependencies>
+      <dependency>
+           <groupId>com.red5pro</groupId>
+           <artifactId>red5pro-mega</artifactId>
+           <version>${red5pro-mega.version}</version>
+       </dependency>
         <dependency>
             <groupId>org.red5</groupId>
             <artifactId>red5-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
         <maven.build.timestamp.format>MM.dd.yyyy HH:mm</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
         <red5pro-common.version>9.1.0</red5pro-common.version>
-        <red5pro-mega.version>8.0.0</red5pro-mega.version>
         <red5.version>1.2.8</red5.version>
         <mina.version>[2.0.21,)</mina.version>
         <spring.version>[5.3.5,)</spring.version>
@@ -87,7 +86,7 @@
                                 <requireMavenVersion>
                                     <version>[3.6.0,)</version>
                                 </requireMavenVersion>
-                            </rules>    
+                            </rules>
                         </configuration>
                     </execution>
                 </executions>
@@ -340,11 +339,6 @@
             <groupId>com.red5pro</groupId>
             <artifactId>red5pro-common</artifactId>
             <version>${red5pro-common.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.red5pro</groupId>
-            <artifactId>red5pro-mega</artifactId>
-            <version>${red5pro-mega.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
         <timestamp>${maven.build.timestamp}</timestamp>
         <red5pro-common.version>9.1.0</red5pro-common.version>
         <red5.version>1.2.8</red5.version>
-         <red5pro-mega.version>9.0.0</red5pro-mega.version>
         <mina.version>[2.0.21,)</mina.version>
         <spring.version>[5.3.5,)</spring.version>
         <httpcomponents.version>[4.5.13,)</httpcomponents.version>
@@ -266,11 +265,6 @@
         </plugins>
     </build>
     <dependencies>
-      <dependency>
-           <groupId>com.red5pro</groupId>
-           <artifactId>red5pro-mega</artifactId>
-           <version>${red5pro-mega.version}</version>
-       </dependency>
         <dependency>
             <groupId>org.red5</groupId>
             <artifactId>red5-server</artifactId>
@@ -296,10 +290,6 @@
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.quartz-scheduler</groupId>
-                    <artifactId>quartz</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.tika</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.red5pro</groupId>
     <artifactId>red5pro-simple-auth</artifactId>
-    <version>5.6.5901</version>
+    <version>9.0.0</version>
     <packaging>jar</packaging>
     <name>red5pro-simple-auth-plugin</name>
     <url>https://github.com/red5pro/red5pro-simple-auth-plugin</url>
@@ -32,15 +32,17 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skipTests>true</skipTests>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.1</maven.compiler.source>
+        <maven.compiler.target>1.1</maven.compiler.target>
+        <java.release.level>11</java.release.level>
         <maven.build.timestamp.format>MM.dd.yyyy HH:mm</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
-        <red5pro-common.version>5.7.0</red5pro-common.version>
-        <red5.version>1.0.10-M7</red5.version>
-        <mina.version>[2.0.19,)</mina.version>
-        <spring.version>[4.3.18,)</spring.version>
-        <httpcomponents.version>4.5.3</httpcomponents.version>
+        <red5pro-common.version>9.1.0</red5pro-common.version>
+        <red5.version>1.2.8</red5.version>
+        <mina.version>[2.0.21,)</mina.version>
+        <spring.version>[5.3.5,)</spring.version>
+        <httpcomponents.version>[4.5.13,)</httpcomponents.version>
+        <junit.version>[4.13.1,)</junit.version>
     </properties>
     <issueManagement>
         <system>github</system>
@@ -67,12 +69,79 @@
         <defaultGoal>clean package</defaultGoal>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[1.11,)</version>
+                                </requireJavaVersion>
+                                <requireMavenVersion>
+                                    <version>[3.6.0,)</version>
+                                </requireMavenVersion>
+                            </rules>    
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <!-- compile everything to ensure module-info contains right entries -->
+                            <release>${java.release.level}</release>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>base-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <!-- recompile everything for target VM except the module-info.java -->
+                        <configuration>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+                <!-- defaults for compile and testCompile -->
                 <configuration>
-                    <fork>true</fork>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
+                    <!-- Only required when JAVA_HOME isn't at least Java 9 and when haven't configured the maven-toolchains-plugin -->
+                    <jdkToolchain>
+                        <version>11</version>
+                    </jdkToolchain>
+                    <verbose>true</verbose>
+                    <release>${java.release.level}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!-- https://maven.apache.org/guides/mini/guide-using-toolchains.html -->
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <toolchains>
+                        <jdk>
+                            <version>[1.11,)</version>
+                        </jdk>
+                    </toolchains>
                 </configuration>
             </plugin>
             <plugin>
@@ -89,7 +158,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -118,6 +187,22 @@
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Build-OS>${os.name} ${os.version}</Build-OS>
+                            <Build-Java>Java ${java.version}</Build-Java>
+                            <Build-Timestamp>${timestamp}</Build-Timestamp>
+                            <!-- Build number comes from git commit and is updated via profile -->
+                            <Build-Number>${buildNumber}</Build-Number>
+                            <Red5-Plugin-Main-Class>com.red5pro.server.plugin.simpleauth.SimpleAuthPlugin</Red5-Plugin-Main-Class>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
                 <version>1.4</version>
@@ -138,25 +223,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Build-OS>${os.name} ${os.version}</Build-OS>
-                            <Build-Java>Java ${java.version}</Build-Java>
-                            <Build-Timestamp>${timestamp}</Build-Timestamp>
-                            <!-- Build number comes from git commit and is updated via profile -->
-                            <Build-Number>${buildNumber}</Build-Number>
-                            <Red5-Plugin-Main-Class>com.red5pro.server.plugin.simpleauth.SimpleAuthPlugin</Red5-Plugin-Main-Class>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>4.2.1</version>
                 <extensions>true</extensions>
             </plugin>
             <!-- Project http://code.revelc.net/formatter-maven-plugin/ -->
@@ -200,6 +269,7 @@
             <groupId>org.red5</groupId>
             <artifactId>red5-server</artifactId>
             <version>${red5.version}</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.red5</groupId>
@@ -240,6 +310,7 @@
             <groupId>org.red5</groupId>
             <artifactId>red5-server-common</artifactId>
             <version>${red5.version}</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -251,6 +322,7 @@
             <groupId>org.red5</groupId>
             <artifactId>red5-io</artifactId>
             <version>${red5.version}</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -275,27 +347,4 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-<!--
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
--->
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <maven.build.timestamp.format>MM.dd.yyyy HH:mm</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
         <red5pro-common.version>9.1.0</red5pro-common.version>
+        <red5pro-mega.version>8.0.0</red5pro-mega.version>
         <red5.version>1.2.8</red5.version>
         <mina.version>[2.0.21,)</mina.version>
         <spring.version>[5.3.5,)</spring.version>
@@ -339,6 +340,11 @@
             <groupId>com.red5pro</groupId>
             <artifactId>red5pro-common</artifactId>
             <version>${red5pro-common.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.red5pro</groupId>
+            <artifactId>red5pro-mega</artifactId>
+            <version>${red5pro-mega.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/red5-pro-simpleauth-custom-validator-kit/src/main/java/com/red5pro/server/plugin/simpleauth/extension/sample/ConnectionUtils.java
+++ b/red5-pro-simpleauth-custom-validator-kit/src/main/java/com/red5pro/server/plugin/simpleauth/extension/sample/ConnectionUtils.java
@@ -39,19 +39,16 @@ public class ConnectionUtils {
      * Returns human readable string for a given IConnection type
      *  
      * @param connection
-     * @return
+     * @return connection type string
      */
     public static String getConnectionType(IConnection connection) {
-        String connectionClassName = connection.getClass().getCanonicalName();
-
-        if (connectionClassName.equalsIgnoreCase(RTMPCONNECTION)) {
+        if (isRTMP(connection)) {
             return "rtmp";
-        } else if (connectionClassName.equalsIgnoreCase(RTSPCONNECTION)) {
+        } else if (isRTSP(connection)) {
             return "rtsp";
-        } else if (connectionClassName.equalsIgnoreCase(RTCCONNECTION)) {
+        } else if (isRTC(connection)) {
             return "rtc";
         }
-
         return null;
     }
 
@@ -59,7 +56,7 @@ public class ConnectionUtils {
      * Returns boolean true if connection is a RTMPMinaConnection object, false otherwise
      * 
      * @param connection
-     * @return
+     * @return true if rtmp and false otherwise
      */
     public static boolean isRTMP(IConnection connection) {
         String connectionClassName = connection.getClass().getCanonicalName();
@@ -70,7 +67,7 @@ public class ConnectionUtils {
      * Returns boolean true if connection is a RTSPMinaConnection object, false otherwise
      * 
      * @param connection
-     * @return
+     * @return true if rtsp and false otherwise
      */
     public static boolean isRTSP(IConnection connection) {
         String connectionClassName = connection.getClass().getCanonicalName();
@@ -81,7 +78,7 @@ public class ConnectionUtils {
      * Returns boolean true if connection is a RTCConnection object, false otherwise
      * 
      * @param connection
-     * @return
+     * @return true if rtc and false otherwise
      */
     public static boolean isRTC(IConnection connection) {
         String connectionClassName = connection.getClass().getCanonicalName();

--- a/src/main/java/com/red5pro/server/plugin/simpleauth/SimpleAuthPlugin.java
+++ b/src/main/java/com/red5pro/server/plugin/simpleauth/SimpleAuthPlugin.java
@@ -254,9 +254,6 @@ public class SimpleAuthPlugin extends Red5Plugin {
 		} catch (Throwable t) {
 			log.error("Error on start", t);
 		}
-
-		String nodeType = System.getProperty("clusterNodeType", "unknown");
-		log.info("Cluster node type: {}", nodeType);
 	}
 
 	/**

--- a/src/main/java/com/red5pro/server/plugin/simpleauth/SimpleAuthPlugin.java
+++ b/src/main/java/com/red5pro/server/plugin/simpleauth/SimpleAuthPlugin.java
@@ -254,6 +254,9 @@ public class SimpleAuthPlugin extends Red5Plugin {
 		} catch (Throwable t) {
 			log.error("Error on start", t);
 		}
+
+		String nodeType = System.getProperty("clusterNodeType", "unknown");
+		log.info("Cluster node type: {}", nodeType);
 	}
 
 	/**

--- a/src/main/java/com/red5pro/server/plugin/simpleauth/datasource/impl/roundtrip/model/AuthData.java
+++ b/src/main/java/com/red5pro/server/plugin/simpleauth/datasource/impl/roundtrip/model/AuthData.java
@@ -37,6 +37,8 @@ public class AuthData {
 
 	private String token;
 
+	private String scope;
+
 	public String getUsername() {
 		return username;
 	}
@@ -77,4 +79,11 @@ public class AuthData {
 		this.type = type;
 	}
 
+	public void setScope(String scope) {
+		this.scope = scope;
+	}
+
+	public String getScope() {
+		return scope;
+	}
 }

--- a/src/main/resources/simple-auth-plugin.properties
+++ b/src/main/resources/simple-auth-plugin.properties
@@ -20,3 +20,6 @@ simpleauth.default.rtmp.queryparams=true
 
 # Allowed rtmp agents
 simpleauth.default.rtmp.agents=*
+
+# Default state of allowing subscribe sessions on origins and transcoders for round trip authentication
+simpleauth.default.subscribe.from.origins=true


### PR DESCRIPTION
The simple authentication plugin has been extended to support receiving a parameter with response data from the authentication server during a `validateCredentials` call. The new parameter has key `authenticationResponseData` and it can be used to send back a string to the Red5 Pro server. The string could be a  regular string, stringified JSON object, JWT token, etc. 

As part of this task also a new `scope` parameter was added to the round trip authentication calls. This parameter will inform clients about the name of the scope where a stream is or was published. 